### PR TITLE
Update MacOS instructions for filesystem creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ sudo apt-get install libtool-bin
 ## MacOS:
 ```bash
 $ brew tap homebrew/dupes
-$ brew install binutils coreutils automake wget gawk libtool gperf gnu-sed --with-default-names grep
+$ brew install binutils coreutils automake wget gawk libtool gperf help2man gnu-sed --with-default-names grep
 $ export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,17 @@ In addition to the development tools MacOS needs a case-sensitive filesystem.
 You might need to create a virtual disk and build esp-open-sdk on it:
 ```bash
 $ hdiutil create ./esp-open-sdk-buildroot.dmg -volname "esp-open-sdk-buildroot" -size 10g -fs "Case-sensitive HFS+" -type SPARSE
-$ hdiutil mount  -mountpoint ./buildroot ./esp-open-sdk-buildroot.dmg.sparseimage
-$ cd ./buildroot
+$ hdiutil mount  -mountpoint ./esp-open-sdk-buildroot ./esp-open-sdk-buildroot.dmg.sparseimage
+$ cd ./esp-open-sdk-buildroot
+```
+
+This small snippet prepares the `PATH` and mounts the image. Load it with `source ./prepare.sh`.
+
+```bash
+# create as sourceme.sh
+export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+hdiutil mount  -mountpoint ./esp-open-sdk-buildroot ./esp-open-sdk-buildroot.dmg.sparseimage
+cd ./esp-open-sdk-buildroot
 ```
 
 Building

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ $ export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 In addition to the development tools MacOS needs a case-sensitive filesystem.
 You might need to create a virtual disk and build esp-open-sdk on it:
 ```bash
-$ sudo hdiutil create ~/Documents/case-sensitive.dmg -volname "case-sensitive" -size 10g -fs "Case-sensitive HFS+"
-$ sudo hdiutil mount ~/Documents/case-sensitive.dmg
-$ cd /Volumes/case-sensitive
+$ hdiutil create ./esp-open-sdk-buildroot.dmg -volname "esp-open-sdk-buildroot" -size 10g -fs "Case-sensitive HFS+" -type SPARSE
+$ hdiutil mount  -mountpoint ./buildroot ./esp-open-sdk-buildroot.dmg.sparseimage
+$ cd ./buildroot
 ```
 
 Building


### PR DESCRIPTION
* `sudo` is not needed to create images or mount images
* create sparse images (very helpful on MacBooks with small disks)
* mount the image in a local folder make it easier todo this in scripts

(tested on El Capitan 10.11.5)